### PR TITLE
Add Chocolatey as default installer for Windows machines

### DIFF
--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -103,6 +103,10 @@ function Set-CSRAttributes
         $CSRAttributes
     )
     $csr_yaml_path = "$env:ProgramData\PuppetLabs\puppet\etc\csr_attributes.yaml"
+    if (Test-Path $csr_yaml_path)
+    {
+        Remove-Item $csr_yaml_path -Confirm:$false -Force
+    }
     $csr_yaml_parent = Split-Path $csr_yaml_path
     if (!(Test-Path $csr_yaml_parent))
     {
@@ -344,7 +348,7 @@ else
     Write-Verbose "Installing Puppet with:`n$InstallationArguments"
     try 
     {
-        $ChocoResult = Start-Process 'choco' -ArgumentList $InstallationArguments -Wait -NoNewWindow -ErrorAction Stop
+        $ChocoResult = Start-Process 'choco' -ArgumentList $InstallationArguments -Wait -NoNewWindow -ErrorAction Stop -PassThru
     }
     catch 
     {

--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -195,11 +195,6 @@ if ($InstallationMethod -eq 'Chocolatey' -and !(Get-Command 'choco' -ErrorAction
         }
     }
 }
-# If we're using the legacy installer we'll need to know our major version of puppet.
-if ($InstallationMethod -eq 'legacy')
-{
-    $PuppetMajorVersion = "puppet" + $PuppetAgentVersion.Substring(0)
-}
 if ($PuppetMaster -notmatch ".$Domainname")
 {
     $PuppetMaster = "$PuppetMaster.$domainname"
@@ -255,6 +250,7 @@ if ($InstallationMethod -eq 'Legacy')
     # For now we're getting the Puppet agent manually but ultimately I'd like to test getting it via chocolatey - that way we can keep the package up to date.
     # Default to x86 but attempt to get x64 where we can.
     Write-Verbose "Using legacy installer"
+    $PuppetMajorVersion = "puppet" + $PuppetAgentVersion.Substring(0)
     $arch = "x86"
     if ( [Environment]::Is64BitOperatingSystem )
     {

--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -334,7 +334,7 @@ if ($InstallationMethod -eq 'Legacy')
 }
 else 
 {
-    $InstallationArguments = 'install puppet-agent'
+    $InstallationArguments = 'install puppet-agent -y'
     if ($PuppetAgentVersion -ne 'latest')
     {
         $InstallationArguments += " --version=$PuppetAgentVersion"

--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -348,7 +348,7 @@ else
     Write-Verbose "Installing Puppet with:`n$InstallationArguments"
     try 
     {
-        $ChocoResult = Start-Process 'choco' -ArgumentList $InstallationArguments -Wait -NoNewWindow -ErrorAction Stop -PassThru
+        $ChocoResult = Start-Process 'choco' -ArgumentList $InstallationArguments -Wait -NoNewWindow -PassThru -ErrorAction Stop
     }
     catch 
     {

--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -335,7 +335,7 @@ else
     {
         $InstallationArguments += " --version=$PuppetAgentVersion"
     }
-    $PuppetArguments = " --install-args='PUPPET_AGENT_STARTUP_MODE=$StartupMode PUPPET_MASTER_SERVER=$($PuppetMaster.ToLower()) PUPPET_AGENT_ENVIRONMENT=$PuppetEnvironment'"
+    $PuppetArguments = " --install-args=`"`'PUPPET_AGENT_STARTUP_MODE=$StartupMode PUPPET_MASTER_SERVER=$($PuppetMaster.ToLower()) PUPPET_AGENT_ENVIRONMENT=$PuppetEnvironment`'`""
     if ($AgentCertName)
     {
         $PuppetArguments = " --install-args=`"`'PUPPET_AGENT_STARTUP_MODE=$StartupMode PUPPET_MASTER_SERVER=$($PuppetMaster.ToLower()) PUPPET_AGENT_ENVIRONMENT=$PuppetEnvironment PUPPET_AGENT_CERTNAME=$($AgentCertName.ToLower())`'`""

--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -166,7 +166,7 @@ if (Get-Command puppet -erroraction silentlycontinue)
 }
 if ($InstallationMethod -eq 'Chocolatey' -and !(Get-Command 'choco' -ErrorAction SilentlyContinue))
 {
-    Write-Warning -Message "Chocolately does not appear to be installed on your system.`nWould you like to install it? (selecing 'n' will revert to legacy instaler)"
+    Write-Warning -Message "Chocolately does not appear to be installed on your system.`nWould you like to install it?"
     while (!$ChocoInstall) 
     {
         $ChocoInstall = Read-Host "Install Chocolatey? [y/n]"
@@ -174,28 +174,25 @@ if ($InstallationMethod -eq 'Chocolatey' -and !(Get-Command 'choco' -ErrorAction
         {
             'y' 
             { 
-                $InstallChocolatey = $true
+                try
+                {
+                    Install-Chocolatey
+                }
+                catch
+                {
+                    throw "Failed to install Chocolatey.`n$($_.Exception.Message)"
+                }
             }
             'n'
             {
-                $InstallationMethod = 'Legacy'
+                Write-Host 'If you want to use the legacy installer, run this script again specifying "-InstallationMethod Legacy"'
+                exit
             }
             Default 
             {
                 Clear-Variable $ChocoInstall # unrecognised input, try again.
             }
         }
-    }
-}
-if ($InstallChocolatey -eq $true)
-{
-    try
-    {
-        Install-Chocolatey
-    }
-    catch
-    {
-        throw "Failed to install Chocolatey.`n$($_.Exception.Message)"
     }
 }
 # If we're using the legacy installer we'll need to know our major version of puppet.

--- a/puppet-windows.ps1
+++ b/puppet-windows.ps1
@@ -182,7 +182,7 @@ if ($PuppetMaster -notmatch ".$Domainname")
 Write-Host "Checking connection to $PuppetMaster"
 if (!(Test-NetConnection $PuppetMaster -InformationLevel Quiet))
 {
-    #throw "Failed to contact $PuppetMaster, please check the name and network connection."
+    throw "Failed to contact $PuppetMaster, please check the name and network connection."
 }
 
 if (!$CertificateExtensions)


### PR DESCRIPTION
We'll use Chocolatey as our default installation method for Puppet Agent as per #15 

This allows us to keep the Puppet Agent up-to-date by using a Puppet module as previously this would fail if Puppet had been installed manually.
However there may be cases where Chocolatey cannot be used so we have the 'legacy' installer option for these cases.

This also addresses and fixes #19 
